### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,37 +4,37 @@ AIRKinect Extension is a Native Extension for use with Adobe AIR 3.0. AIRKinect 
 
 You can find the compiled .ane file in the bin directory of this repository.
 
-##Driver Installation
+## Driver Installation
 
 
 Before you can use the native extension in your AIR project, you will need to install the kinect drivers. You have several options, depending on your platform.
 
 
-###Windows:
+### Windows:
 
 
-####MS SDK version: (airkinect-2-core-mssdk.ane)
+#### MS SDK version: (airkinect-2-core-mssdk.ane)
 
 1. Install Microsoft Kinect SDK: <http://kinectforwindows.org/>
 2. That's it
 
-####OpenNI version: (airkinect-2-core-openni.ane)
+#### OpenNI version: (airkinect-2-core-openni.ane)
 
 You can use the instructions "Install OpenNI,NITE and the Sensor Driver" of the SimpleOpenNI project to get OpenNI up and running on your windows 7 machine: <https://code.google.com/p/simple-openni/wiki/Installation_PreOpenNI2#Windows>. Make sure you install the 32-bit version. AIRKinect does not work with the 64-bit version.
 
 
-###OSX 10.6+:
+### OSX 10.6+:
 
 You can use the instructions "Install OpenNI the short way" of the SimpleOpenNI project to get OpenNI up and running on your OSX machine: <https://code.google.com/p/simple-openni/wiki/Installation_PreOpenNI2#OSX>.
 
-##Linking AIRKinect to your project
+## Linking AIRKinect to your project
 
 
 All you need is the ane file matching your driver. If you are using the MS SDK, you will need [airkinect-2-core-mssdk.ane](https://github.com/AS3NUI/airkinect-2-core/raw/master/bin/airkinect-2-core-mssdk.ane), if you are using OpenNI, you will need [airkinect-2-core-openni.ane](https://github.com/AS3NUI/airkinect-2-core/raw/master/bin/airkinect-2-core-openni.ane).
 
 Once you have the correct file, you will need to link it to your AIR project:
 
-###Flash Builder 4.6
+### Flash Builder 4.6
 
 
 1. Right click on your AIR for desktop project and choose properties.
@@ -42,14 +42,14 @@ Once you have the correct file, you will need to link it to your AIR project:
 3. In that same window, choose Native Extensions and click on Add ANE… Select that same ane file.
 4. Select Actionscript Build Packaging > Native extensions. Check the checkbox next to the native extension. Ignore the warning that says the extension isn't used.
 
-###Flash CS6
+### Flash CS6
 
 
 1. Go the File > Actionscript settings.
 2. On the Library Path tab, click on the "Browse to a Native Extension (ANE)" button (button to the right of the SWC button)
 3. Choose the ane file you just downloaded.
 
-###IntelliJ IDEA
+### IntelliJ IDEA
 
 
 1. Right click on your module and choose "Open Module Settings".
@@ -57,7 +57,7 @@ Once you have the correct file, you will need to link it to your AIR project:
 3. Click on the plus (+) button on the bottom of that window and choose "New Library…"
 4. Choose the ane file you just downloaded
 
-##Basic Usage
+## Basic Usage
 
 
 AIRKinect has a lot of built-in features. You can check some examples in our [examples repository](https://github.com/AS3NUI/airkinect-2-examples).
@@ -87,7 +87,7 @@ A quick example, showing the depth image would be something like this:
 
 
 
-##License
+## License
 Copyright 2012 AS3NUI
 Licensed under the Apache License, Version 2.0 (the ""License");
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
